### PR TITLE
Return false when object is null and there are still paths to check

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,10 @@ function hasKeyDeep(key, object) {
       return true;
   }
 
+  if (!object) {
+      return false;
+  }
+
   // Termination case (2)
   if (key.length === 1) {
       return object.hasOwnProperty(key[0]);

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@ var hasKeyDeep = require('./index');
 
 describe('hasKeyDeep()', function () {
   var testObject = { a: { b: { c: 1 } } };
+  var testObjectForNullObjects = { a: { b: null } }
 
   context('empty object', function () {
     it('should return false when query is a string', function () {
@@ -28,6 +29,11 @@ describe('hasKeyDeep()', function () {
     it('should return true when the key is present (3)', function () {
       assert(hasKeyDeep('a.b.c', testObject));
     });
+    it('should not throw when object is null in path', function () {
+      assert.doesNotThrow(function () {
+        hasKeyDeep('a.b.c', testObjectForNullObjects)
+      });
+    });
   });
 
   context('valid array queries', function () {
@@ -41,6 +47,11 @@ describe('hasKeyDeep()', function () {
 
     it('should return true when the key is present (3)', function () {
       assert(hasKeyDeep(['a', 'b', 'c'], testObject));
+    });
+    it('should not throw when object is null in path', function () {
+      assert.doesNotThrow(function () {
+        hasKeyDeep(['a', 'b', 'c'], testObjectForNullObjects)
+      });
     });
   });
 

--- a/test.js
+++ b/test.js
@@ -29,11 +29,6 @@ describe('hasKeyDeep()', function () {
     it('should return true when the key is present (3)', function () {
       assert(hasKeyDeep('a.b.c', testObject));
     });
-    it('should not throw when object is null in path', function () {
-      assert.doesNotThrow(function () {
-        hasKeyDeep('a.b.c', testObjectForNullObjects)
-      });
-    });
   });
 
   context('valid array queries', function () {
@@ -47,11 +42,6 @@ describe('hasKeyDeep()', function () {
 
     it('should return true when the key is present (3)', function () {
       assert(hasKeyDeep(['a', 'b', 'c'], testObject));
-    });
-    it('should not throw when object is null in path', function () {
-      assert.doesNotThrow(function () {
-        hasKeyDeep(['a', 'b', 'c'], testObjectForNullObjects)
-      });
     });
   });
 
@@ -67,6 +57,11 @@ describe('hasKeyDeep()', function () {
     it('should return false when the key is not present (3)', function () {
       assert(!hasKeyDeep('c', testObject));
     });
+    it('should not throw when object is null in path', function () {
+      assert.doesNotThrow(function () {
+        hasKeyDeep('a.b.c', testObjectForNullObjects)
+      });
+    });
   });
 
   context('invalid array queries', function () {
@@ -80,6 +75,11 @@ describe('hasKeyDeep()', function () {
 
     it('should return false when the key is not present (3)', function () {
       assert(!hasKeyDeep(['c'], testObject));
+    });
+    it('should not throw when object is null in path', function () {
+      assert.doesNotThrow(function () {
+        hasKeyDeep(['a', 'b', 'c'], testObjectForNullObjects)
+      });
     });
   });
 });


### PR DESCRIPTION
https://github.com/ryanaghdam/propDeep/issues/1

This fixes an issue where `has-key-deep` (and by extension `propDeep`) throws a `TypeError: Cannot read property 'hasOwnProperty' of null` in this scenario:

```
var a = { b: null }
hasKeyDeep ('b.c', a)
```

Here's the new behavior in my REPL:

```
> var a = { b: null }
undefined
> hasKeyDeep('b.c', a)
false
> hasKeyDeep('b', a)
true
```
