### PR TITLE
avoid partial application when object is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@
 function hasKeyDeep(key, object) {
   // key is a string, then call the function with an array representation of
   // the value
-  if (typeof key === "string") {
-    return hasKeyDeep(key.split("."), object);
+  if (typeof key === 'string') {
+    return hasKeyDeep(key.split('.'), object);
   }
 
   // Termination case (1)
@@ -17,7 +17,7 @@ function hasKeyDeep(key, object) {
     return true;
   }
 
-  // Termination case (2)
+   // Termination case (2)
   if (!object) {
     return false;
   }
@@ -35,9 +35,9 @@ function hasKeyDeep(key, object) {
   return false;
 }
 
-module.exports = function(key, object) {
+module.exports = function (key, object) {
   if (arguments.length === 1) {
-    return function(o) {
+    return function (o) {
       return hasKeyDeep(key, o);
     };
   }

--- a/index.js
+++ b/index.js
@@ -35,12 +35,13 @@ function hasKeyDeep(key, object) {
   return false;
 }
 
-module.exports = function (...args) {
+module.exports = function () {
+  const args = arguments;
   if (args.length === 1) {
     return function (o) {
       return hasKeyDeep(args[0], o);
     };
   }
 
-  return hasKeyDeep(...args);
+  return hasKeyDeep(args[0], args[1]);
 };

--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@
 function hasKeyDeep(key, object) {
   // key is a string, then call the function with an array representation of
   // the value
-  if (typeof key === 'string') {
-    return hasKeyDeep(key.split('.'), object);
+  if (typeof key === "string") {
+    return hasKeyDeep(key.split("."), object);
   }
 
   // Termination case (1)
@@ -17,7 +17,7 @@ function hasKeyDeep(key, object) {
     return true;
   }
 
-   // Termination case (2)
+  // Termination case (2)
   if (!object) {
     return false;
   }
@@ -35,13 +35,12 @@ function hasKeyDeep(key, object) {
   return false;
 }
 
-module.exports = function () {
-  const args = arguments;
-  if (args.length === 1) {
-    return function (o) {
-      return hasKeyDeep(args[0], o);
+module.exports = function(key, object) {
+  if (arguments.length === 1) {
+    return function(o) {
+      return hasKeyDeep(key, o);
     };
   }
 
-  return hasKeyDeep(args[0], args[1]);
+  return hasKeyDeep(key, object);
 };

--- a/index.js
+++ b/index.js
@@ -35,12 +35,12 @@ function hasKeyDeep(key, object) {
   return false;
 }
 
-module.exports = function (key, object) {
-  if (typeof object === 'undefined') {
+module.exports = function (...args) {
+  if (args.length === 1) {
     return function (o) {
-      return hasKeyDeep(key, o);
+      return hasKeyDeep(args[0], o);
     };
   }
 
-  return hasKeyDeep(key, object);
+  return hasKeyDeep(...args);
 };

--- a/test.js
+++ b/test.js
@@ -84,7 +84,7 @@ describe('hasKeyDeep()',  function() {
         assert(!hasKeyDeep('a.b.c', { a: undefined }));
       });
 
-      it('should return false when the object is undefined', () => {
+      it('should return false when the object is undefined', function() {
         assert(!hasKeyDeep('a.b.c', undefined));
       });
     });
@@ -110,7 +110,7 @@ describe('hasKeyDeep()',  function() {
         assert(!hasKeyDeep(['a', 'b', 'c'], { a: undefined }));
       });
 
-      it('should return false when the object is undefined', () => {
+      it('should return false when the object is undefined', function() {
         assert(!hasKeyDeep(['a', 'b', 'c'], undefined));
       });
     });
@@ -194,7 +194,7 @@ describe('hasKeyDeep()',  function() {
         assert(!hasKeyDeep('a.b.c')({ a: undefined }));
       });
 
-      it('should return false when the object is undefined', () => {
+      it('should return false when the object is undefined', function() {
         assert(!hasKeyDeep('a.b.c')(undefined));
       });
     });
@@ -220,7 +220,7 @@ describe('hasKeyDeep()',  function() {
         assert(!hasKeyDeep(['a', 'b', 'c'])({ a: undefined }));
       });
 
-      it('should return false when the object is undefined', () => {
+      it('should return false when the object is undefined', function() {
         assert(!hasKeyDeep(['a', 'b', 'c'])(undefined));
       });
     });

--- a/test.js
+++ b/test.js
@@ -83,6 +83,10 @@ describe('hasKeyDeep()',  function() {
       it('should return false when an earlier value is undefined',  function() {
         assert(!hasKeyDeep('a.b.c', { a: undefined }));
       });
+
+      it('should return false when the object is undefined', () => {
+        assert(!hasKeyDeep('a.b.c', undefined));
+      });
     });
 
     context('invalid array queries',  function() {
@@ -104,6 +108,10 @@ describe('hasKeyDeep()',  function() {
 
       it('should return false when an earlier value is undefined',  function() {
         assert(!hasKeyDeep(['a', 'b', 'c'], { a: undefined }));
+      });
+
+      it('should return false when the object is undefined', () => {
+        assert(!hasKeyDeep(['a', 'b', 'c'], undefined));
       });
     });
   });
@@ -185,6 +193,10 @@ describe('hasKeyDeep()',  function() {
       it('should return false when an earlier value is undefined',  function() {
         assert(!hasKeyDeep('a.b.c')({ a: undefined }));
       });
+
+      it('should return false when the object is undefined', () => {
+        assert(!hasKeyDeep('a.b.c')(undefined));
+      });
     });
 
     context('invalid array queries',  function() {
@@ -206,6 +218,10 @@ describe('hasKeyDeep()',  function() {
 
       it('should return false when an earlier value is undefined',  function() {
         assert(!hasKeyDeep(['a', 'b', 'c'])({ a: undefined }));
+      });
+
+      it('should return false when the object is undefined', () => {
+        assert(!hasKeyDeep(['a', 'b', 'c'])(undefined));
       });
     });
   });


### PR DESCRIPTION
so `hasKeyDeep('some.path', undefined)` returns `false` instead of a function